### PR TITLE
Update to use proptype package so there is no react warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "babel-core": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0"
-  }
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10",
+  },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import NonPreviewDefaultComponent from './nonPreviewDefaultComponent';
 
 export default class FileInputBase64PreviewComponent extends Component {
@@ -160,21 +161,21 @@ FileInputBase64PreviewComponent.defaultProps = {
 }
 
 FileInputBase64PreviewComponent.propTypes = {
-  inputName: React.PropTypes.string,
-  inputId: React.PropTypes.string,
-  callbackFunction: React.PropTypes.func,
-  labelText: React.PropTypes.string,
-  useTapEventPlugin: React.PropTypes.bool,
-  multiple: React.PropTypes.bool,
-  imagePreview: React.PropTypes.bool,
-  textBoxVisible: React.PropTypes.bool,
-  accept: React.PropTypes.string,
-  imageContainerStyle: React.PropTypes.object,
-  imageStyle: React.PropTypes.object,
-  labelStyle: React.PropTypes.object,
-  parentStyle: React.PropTypes.object,
-  buttonComponent: React.PropTypes.element,
-  nonPreviewComponent: React.PropTypes.element,
-  textFieldComponent: React.PropTypes.element,
-  defaultFiles: React.PropTypes.array
+  inputName: PropTypes.string,
+  inputId: PropTypes.string,
+  callbackFunction: PropTypes.func,
+  labelText: PropTypes.string,
+  useTapEventPlugin: PropTypes.bool,
+  multiple: PropTypes.bool,
+  imagePreview: PropTypes.bool,
+  textBoxVisible: PropTypes.bool,
+  accept: PropTypes.string,
+  imageContainerStyle: PropTypes.object,
+  imageStyle: PropTypes.object,
+  labelStyle: PropTypes.object,
+  parentStyle: PropTypes.object,
+  buttonComponent: PropTypes.element,
+  nonPreviewComponent: PropTypes.element,
+  textFieldComponent: PropTypes.element,
+  defaultFiles: PropTypes.array
 }


### PR DESCRIPTION
I get this warning in the console because using PropTypes from the main React package is being deprecated. Here is the warning message.

lowPriorityWarning.js:40 Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs